### PR TITLE
Update service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Manage vaccinations for school-aged children prototype
+# Manage vaccinations in schools prototype
 
 View the prototype:
 https://poc-prototype.herokuapp.com/

--- a/app/views/dashboard.html
+++ b/app/views/dashboard.html
@@ -1,6 +1,6 @@
 {% extends "_layouts/default.html" %}
 
-{% set title = "Manage vaccinations for school-aged children" %}
+{% set title = serviceName + " (MAVIS)" %}
 
 {% block content %}
   {% if hasOfflineChanges %}

--- a/app/views/emails/invite-new-user.html
+++ b/app/views/emails/invite-new-user.html
@@ -2,7 +2,7 @@
 
 {% set title = "Check and confirm details" %}
 {% set subject = "You can now record vaccinations" %}
-{% set from = "Manage vaccinations for school-aged children <manage-school-aged-vaccinations@nhs.net>" %}
+{% set from = serviceName + " <manage-vaccinations-in-schools@nhs.net>" %}
 {% set name = data.users["123"].fullName if data.users["123"] else "Jane Doe" %}
 {% set to = name + " <" + data.users["123"].email + ">" if data.users["123"] else false %}
 
@@ -10,7 +10,7 @@
   <p>Dear {{ name }},</p>
   <p>You can now use the Record children’s vaccinations service.</p>
   <p>Confirm your contact details and set a password by going to:</p>
-  <p><a href="#">https://www.manage-school-aged-vaccinations.service.nhs.uk/invitation?w=12345</a></p>
+  <p><a href="#">https://manage-vaccinations-in-schools.nhs.uk/invitation?w=12345</a></p>
   <p>If you have any problems, contact [contact telephone number]</p>
   <p>[Name of SAIS team]</p>
 {% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -1,6 +1,6 @@
 {% extends "_layouts/default.html" %}
 
-{% set title = "Manage vaccinations for school-aged children" %}
+{% set title = serviceName + " (MAVIS)" %}
 
 {% block content %}
   <div class="nhsuk-grid-row">

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": "^20"
   },
   "prototype": {
-    "serviceName": "Manage vaccinations for school-aged children",
+    "serviceName": "Manage vaccinations in schools",
     "defaultRigLayout": "_layouts/default.html"
   },
   "stylelint": {


### PR DESCRIPTION
During research with SAIS teams, we received feedback on the service name, chiefly that a shorter name for the service would be useful when referencing it within teams, as is the case with existing systems.

However, this need should be weighed up against guidance that service names should use verbs, not nouns.

However, whatever we call it, a shorthand will end up being used by SAIS teams, so it makes sense for us to think of a name ahead of time that can be easily abbreviated, and hint towards that appreciation being approved.

Changing the name from ‘Manage vaccinations for school-aged children’ to ‘Manage vaccinations in schools’, not only do we have a shorter ‘official’ name, but this can be abbreviated to ‘MAVIS’.[^1]

This PR renames the service to ‘Manage vaccinations in schools’, adding the MAVIS  abbreviation to the page heading on the service landing and signed in dashboard pages inside brackets.

[^1]: This is an internal service, used by nurses and school admins. For the wider public service, the existing name (‘Give or refuse consent for vaccinations’) will be retained.