### PR TITLE
Add view for vaccinate later

### DIFF
--- a/app/routes/_filters.js
+++ b/app/routes/_filters.js
@@ -66,6 +66,11 @@ const filters = {
       outcome !== PATIENT_OUTCOME.VACCINATED
     )
   },
+  vaccinateLater: (cohort) => {
+    return cohort.filter(({ triage }) =>
+      triage?.outcome === TRIAGE_OUTCOME.DELAY_VACCINATION
+    )
+  },
   hasOutcome: (cohort, value) => {
     return cohort.filter(({ outcome }) => {
       return outcome === PATIENT_OUTCOME[value]
@@ -101,6 +106,7 @@ export default (req, res) => {
 
   // Record filters
   let vaccinatedResults = filter(cohort, 'hasOutcome', 'VACCINATED')
+  const vaccinateLaterResults = filter(cohort, 'vaccinateLater')
   let couldNotVaccinateResults = filter(cohort, 'hasOutcome', 'COULD_NOT_VACCINATE')
   const readyToVaccinateResults = filter(cohort, 'readyToVaccinate')
 
@@ -172,6 +178,11 @@ export default (req, res) => {
     vaccinated: {
       label: `Vaccinated (${vaccinatedResults.length})`,
       results: sort(vaccinatedResults),
+      statusColumn: 'Outcome'
+    },
+    vaccinateLater: {
+      label: `Vaccinate later (${vaccinateLaterResults.length})`,
+      results: sort(vaccinateLaterResults),
       statusColumn: 'Outcome'
     },
     couldNotVaccinate: {

--- a/app/routes/vaccination.js
+++ b/app/routes/vaccination.js
@@ -1,5 +1,5 @@
 import { vaccination } from '../wizards/vaccination.js'
-import { PATIENT_OUTCOME, VACCINATION_OUTCOME } from '../enums.js'
+import { PATIENT_OUTCOME, TRIAGE_OUTCOME, VACCINATION_OUTCOME } from '../enums.js'
 import _ from 'lodash'
 
 export default (router) => {
@@ -139,13 +139,21 @@ export default (router) => {
         outcome: VACCINATION_OUTCOME.VACCINATED,
         notes
       }
-    } else {
+    } else if (outcome === VACCINATION_OUTCOME.REFUSED) {
       patient.outcome = PATIENT_OUTCOME.COULD_NOT_VACCINATE
       patient.seen = {
         text: PATIENT_OUTCOME.COULD_NOT_VACCINATE,
-        outcome: VACCINATION_OUTCOME.REFUSED,
+        outcome,
         notes
       }
+    } else {
+      patient.outcome = PATIENT_OUTCOME.NO_OUTCOME_YET
+      patient.seen = {
+        text: PATIENT_OUTCOME.NO_OUTCOME_YET,
+        outcome,
+        notes
+      }
+      patient.triage.outcome = TRIAGE_OUTCOME.DELAY_VACCINATION
     }
 
     res.locals.patient.seen.isOffline = res.locals.isOffline

--- a/app/views/sessions/record.html
+++ b/app/views/sessions/record.html
@@ -44,6 +44,11 @@
     {% include "sessions/_tab.html" %}
   {% endset %}
 
+  {% set vaccinateLater %}
+    {% set tab = filters.vaccinateLater %}
+    {% include "sessions/_tab.html" %}
+  {% endset %}
+
   {% set couldNotVaccinate %}
     {% set tab = filters.couldNotVaccinate %}
     {% include "sessions/_tab.html" %}
@@ -60,6 +65,11 @@
         id: "vaccinated",
         label: filters.vaccinated.label,
         panel: { html: vaccinated }
+      },
+      {
+        id: "vaccinateLater",
+        label: filters.vaccinateLater.label,
+        panel: { html: vaccinateLater }
       },
       {
         id: "not-vaccinated",


### PR DESCRIPTION
Add a ‘Vaccinate later’ tab to record view. This should show records where:

* Triage outcome was set to Delay vaccination
* Vaccination outcome was one of:
  * They refused it
  * They were not well enough
  * They had contraindications
  * They were absent from the session

This is a pretty crude means of outcoming all patients. A more complete solution can come later.

<img width="995" alt="Screenshot of ‘Vaccinate later’ tab." src="https://github.com/nhsuk/manage-childrens-vaccinations-prototype/assets/813383/346c2bcb-45bc-4898-9c2e-e9bd2c67174f">
