### PR TITLE
Add additional metadata for vaccines, batches and doses

### DIFF
--- a/app/fakers/batch.js
+++ b/app/fakers/batch.js
@@ -14,17 +14,17 @@ import { faker } from '@faker-js/faker'
  * @returns {Batch} Batch
  */
 export default () => {
-  const daysUntilExpiry = faker.number.int({ min: 10, max: 50 })
-  const expiryDate = DateTime.now().plus({ days: daysUntilExpiry }).toISODate()
+  const enteredDate = faker.date.recent({ days: 70 })
+  const expiryDate = faker.date.recent({ days: 50 })
 
   const batch = {
     id: faker.helpers.replaceSymbols('??####'),
-    daysUntilExpiry,
+    enteredDate,
     expiryDate,
     expiry: {
-      day: expiryDate.split('-')[2],
-      month: expiryDate.split('-')[1],
-      year: expiryDate.split('-')[0]
+      day: DateTime.fromJSDate(expiryDate).toFormat('dd'),
+      month: DateTime.fromJSDate(expiryDate).toFormat('MM'),
+      year: DateTime.fromJSDate(expiryDate).toFormat('yyyy')
     }
   }
 

--- a/app/filters.js
+++ b/app/filters.js
@@ -1,6 +1,7 @@
 import { DateTime } from 'luxon'
-import { relationshipName } from './utils/relationship.js'
 import prototypeFilters from '@x-govuk/govuk-prototype-filters/index.js'
+import { relationshipName } from './utils/relationship.js'
+import { VACCINATION_OUTCOME } from './enums.js'
 const { plural } = prototypeFilters
 
 export default (_env) => {
@@ -40,7 +41,7 @@ export default (_env) => {
   }
 
   /**
-   * Formatted date with day of the week
+   * Format date with day of the week
    * @param {string} string - ISO date, for example 07-12-2021
    * @returns {string} Formatted date, for example Sunday 7 December 2021
    */
@@ -49,7 +50,25 @@ export default (_env) => {
   }
 
   /**
-   * Formatted NHS number
+   * Format dosage
+   * @param {number} number - Dosage
+   * @param {object} vaccination - Vaccination record
+   * @returns {string} Formatted NHS number
+   */
+  filters.formatDose = (number, vaccination) => {
+    const text = vaccination.outcome === VACCINATION_OUTCOME.PART_VACCINATED
+      ? 'Half'
+      : 'Full'
+
+    const dose = vaccination.outcome === VACCINATION_OUTCOME.PART_VACCINATED
+      ? number / 2
+      : number
+
+    return `${text} (${dose}ml)`
+  }
+
+  /**
+   * Format NHS number
    * @param {string} nhsNumber - NHS Number
    * @returns {string} Formatted NHS number
    */

--- a/app/utils/campaign.js
+++ b/app/utils/campaign.js
@@ -52,17 +52,23 @@ export const vaccines = (type) => {
       return [
         // https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1107978/Influenza-green-book-chapter19-16September22.pdf
         {
+          gtin: '05000456078276',
           type: 'Flu',
           vaccine: 'Flu',
           brand: 'Fluenz Tetra',
+          supplier: 'AstraZeneca UK Ltd',
           method: 'Nasal spray',
+          dose: 0.2,
           isFlu: true
         },
         {
+          gtin: '5000123114115',
           type: 'Flu',
           vaccine: 'Flu',
           brand: 'Fluarix Tetra',
+          supplier: 'GlaxoSmithKline UK Ltd',
           method: 'Injection',
+          dose: 0.5,
           isFlu: true
         }
       ]
@@ -71,10 +77,13 @@ export const vaccines = (type) => {
         // Possible others: Gardasil, Cervarix
         // https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1065283/HPV-greenbook-chapter-18a.pdf
         {
+          gtin: '00191778001693',
           type: 'HPV',
           vaccine: 'HPV',
           brand: 'Gardasil 9',
+          supplier: 'Merck Sharp & Dohme (UK) Ltd',
           method: 'Injection',
+          dose: 0.5,
           isHPV: true
         }
       ]
@@ -83,19 +92,25 @@ export const vaccines = (type) => {
         // Possible others: Pediacel, Repevax, Infanrix IPV
         // https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/147952/Green-Book-Chapter-15.pdf
         {
+          gtin: '3664798042948',
           type: '3-in-1 and MenACWY',
           vaccine: '3-in-1',
           brand: 'Revaxis',
+          supplier: 'Sanofi',
           method: 'Injection',
+          dose: 0.5,
           is3in1: true
         },
         // Menveo, Nimenrix and MenQuadfi
         // https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1076053/Meningococcal-greenbook-chapter-22_17May2022.pdf
         {
+          gtin: '5415062370568',
           type: '3-in-1 and MenACWY',
           vaccine: 'MenACWY',
           brand: 'Nimenrix',
+          supplier: 'Pfizer Ltd',
           method: 'Injection',
+          dose: 0.5,
           isMenACWY: true
         }
       ]

--- a/app/views/patient/_outcome.html
+++ b/app/views/patient/_outcome.html
@@ -6,7 +6,8 @@
 
   {% set vaccineSummary %}
     {% set vaccine = data.vaccines[vaccination.vaccineId] %}
-    {{ vaccine.summary | replace(")", "") }}, {{ vaccine.batches[vaccination.batchId].id }})
+    {% set batch = vaccine.batches[vaccination.batchId] %}
+    {{ vaccine.summary | replace(")", "") }}, {{ batch.id }})
   {% endset %}
 
   {{ summaryList({
@@ -27,8 +28,8 @@
       } if vaccineGiven,
       {
         key: "Dose",
-        value: "Half" if vaccination.outcome == VACCINATION_OUTCOME.PART_VACCINATED else "Full"
-      } if vaccineGiven and session.type == "Flu",
+        value: vaccine.dose | formatDose(vaccination)
+      } if vaccineGiven,
       {
         key: "Site",
         value: vaccination.otherSite or vaccination.site

--- a/app/views/vaccination/_single-vaccine-summary.html
+++ b/app/views/vaccination/_single-vaccine-summary.html
@@ -26,8 +26,8 @@
     } if vaccineGiven,
     {
       key: "Dose",
-      value: "Half" if vaccination.outcome == VACCINATION_OUTCOME.PART_VACCINATED else "Full"
-    } if vaccineGiven and type == "Flu",
+      value: vaccine.dose | formatDose(vaccination)
+    } if vaccineGiven,
     {
       key: "Brand",
       value: vaccine.brand + " (" + vaccine.method + ")",

--- a/app/views/vaccines/index.html
+++ b/app/views/vaccines/index.html
@@ -2,51 +2,50 @@
 {% set title = "Manage vaccines" %}
 
 {% block content %}
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-two-thirds">
-      {{ heading({ title: title, size: "xl" }) }}
+  {{ heading({ title: title, size: "xl" }) }}
 
-      {{ button({
-        href: "#",
-        text: "Add a new vaccine"
-      }) }}
+  {{ button({
+    href: "#",
+    text: "Add a new vaccine"
+  }) }}
 
-      {% for vaccine in vaccines %}
-        {% set descriptionHtml %}
-          <p class="nhsuk-body"><a href="#">Add a batch</a></p>
+  {% for vaccine in vaccines %}
+    {% set descriptionHtml %}
+      <p class="nhsuk-hint nhsuk-u-font-size-16">
+        {{ vaccine.supplier }}, GTIN: {{ vaccine.gtin }}
+      </p>
 
-          <table class="nhsuk-table">
-            <thead class="nhsuk-table__head">
-              <tr class="nhsuk-table__row">
-                <th class="nhsuk-table__header" style="width: 30%">Batch</th>
-                <th class="nhsuk-table__header" style="width: 50%">Expiry</th>
-                <th class="nhsuk-table__header"></th>
-                <th class="nhsuk-table__header"></th>
-              </tr>
-            </thead>
-            <tbody class="nhsuk-table__body">
-            {% for batchId, batch in vaccine.batches %}
-              <tr class="nhsuk-table__row">
-                <td class="nhsuk-table__cell">{{ batchId }}</td>
-                <td class="nhsuk-table__cell">{{ batch.expiry | isoDateFromDateInput | govukDate }}</td>
-                <td class="nhsuk-table__cell nhsuk-u-text-align-right">
-                  <a href="/vaccines/{{ vaccine.id }}/{{ batchId }}">Change</a>
-                </td>
-                <td class="nhsuk-table__cell nhsuk-u-text-align-right">
-                  <a href="#">Move&nbsp;to&nbsp;archive</a>
-                </td>
-              </tr>
-            {% endfor %}
-            </tbody>
-          </table>
-        {% endset %}
+      <p class="nhsuk-body"><a href="#">Add a batch</a></p>
 
-        {{ card({
-          heading: vaccine.brand + " (" + vaccine.vaccine + ")",
-          headingClasses: "nhsuk-heading-m",
-          descriptionHtml: descriptionHtml
-        }) }}
-      {% endfor %}
-    </div>
-  </div>
+      <table class="nhsuk-table">
+        <thead class="nhsuk-table__head">
+          <tr class="nhsuk-table__row">
+            <th class="nhsuk-table__header">Batch</th>
+            <th class="nhsuk-table__header">Entered</th>
+            <th class="nhsuk-table__header">Expiry</th>
+            <th class="nhsuk-table__header"></th>
+          </tr>
+        </thead>
+        <tbody class="nhsuk-table__body">
+        {% for batchId, batch in vaccine.batches %}
+          <tr class="nhsuk-table__row">
+            <td class="nhsuk-table__cell">{{ batchId }}</td>
+            <td class="nhsuk-table__cell">{{ batch.expiry | isoDateFromDateInput | govukDate }}</td>
+            <td class="nhsuk-table__cell">{{ batch.enteredDate | govukDate }}</td>
+            <td class="nhsuk-table__cell nhsuk-u-text-align-right">
+              <a class="nhsuk-u-margin-right-2" href="/vaccines/{{ vaccine.id }}/{{ batchId }}">Change</a>
+              <a href="#">Archive</a>
+            </td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    {% endset %}
+
+    {{ card({
+      heading: vaccine.brand + " (" + vaccine.vaccine + ")",
+      headingClasses: "nhsuk-heading-m  nhsuk-u-margin-bottom-1",
+      descriptionHtml: descriptionHtml
+    }) }}
+  {% endfor %}
 {% endblock %}


### PR DESCRIPTION
1. For vaccines, show supplier and GTIN code and for a batch show when it was entered into MAVIS:

    <img width="1008" alt="Screenshot of Manage vaccines page." src="https://github.com/nhsuk/manage-childrens-vaccinations-prototype/assets/813383/0eb96271-d470-418d-bc7e-60c17ecefec1">

    We don’t have any flows for adding vaccines yet, but it’s likely we wouldn’t ask users to enter any besides a GTIN code, and then potentially pull the necessary data from an upstream data source? TBD.

2. When vaccinating, show the dosage in millilitres:

    <img width="678" alt="Screenshot of dosage being shown when recording a vaccination." src="https://github.com/nhsuk/manage-childrens-vaccinations-prototype/assets/813383/98f96533-cebd-49e0-af2a-b1eb0974f036">
