### PR TITLE
Add ability to add, edit and show user registration numbers

### DIFF
--- a/app/fakers/response.js
+++ b/app/fakers/response.js
@@ -65,9 +65,11 @@ const _getResponse = (type, patient, status) => {
   ])
   const days = faker.number.int({ min: 10, max: 35 })
 
+  const user = getParent(patient)
+
   const response = {
     status,
-    parentOrGuardian: getParent(patient),
+    parentOrGuardian: user,
     ...(status === RESPONSE_CONSENT.GIVEN) && {
       healthAnswers: getHealthAnswers(type, patient)
     },
@@ -77,7 +79,7 @@ const _getResponse = (type, patient, status) => {
         refusalReasonOther: 'My family rejects vaccinations on principle.'
       }
     },
-    events: [getEvent(`${status} (${method.toLowerCase()})`, { days })]
+    events: [getEvent(`${status} (${method.toLowerCase()})`, { days, user })]
   }
 
   return response

--- a/app/fakers/user.js
+++ b/app/fakers/user.js
@@ -7,7 +7,32 @@ import { fakerEN_GB as faker } from '@faker-js/faker'
  * @property {string} lastName - Last/family name
  * @property {string} fullName - Full name
  * @property {string} email - Email address
+ * @property {string} registrationBody - Professional body
+ * @property {string} registration - Registration number
  */
+
+const regulators = {
+  // https://www.gmc-uk.org/registration-and-licensing/the-medical-register
+  gmc: {
+    name: 'General Medical Council',
+    registrationFormat: '#######'
+  },
+  // https://www.pharmacyregulation.org/registers
+  gphc: {
+    name: 'General Pharmaceutical Council',
+    registrationFormat: '#######'
+  },
+  // https://www.hcpc-uk.org/public/be-sure-check-the-register/
+  hcpc: {
+    name: 'Health and Care Professions Council',
+    registrationFormat: 'SW######' // Social worker
+  },
+  // https://www.nmc.org.uk/globalassets/sitedocuments/registration/application-for-transferring-from-the-temporary-register-to-the-permanen....pdf
+  nmc: {
+    name: 'Nursing and Midwifery Council',
+    registrationFormat: '##?####?'
+  }
+}
 
 /**
  * Generate user
@@ -16,6 +41,20 @@ import { fakerEN_GB as faker } from '@faker-js/faker'
 export default () => {
   const firstName = faker.person.lastName()
   const lastName = faker.person.lastName()
+
+  // 'gmc', 'gphc', 'hcpc' or 'nmc'
+  const registrationBody = faker.helpers.weightedArrayElement(
+    [
+      { weight: 3, value: 'gmc' },
+      { weight: 1, value: 'gphc' },
+      { weight: 5, value: 'nmc' },
+      { weight: 1, value: 'hcpc' }
+    ]
+  )
+
+  const registration = faker.helpers.replaceSymbols(
+    regulators[registrationBody].registrationFormat
+  )
 
   const user = {
     id: faker.string.uuid(),
@@ -26,7 +65,9 @@ export default () => {
       firstName,
       lastName,
       provider: 'sais.nhs.uk'
-    }).replaceAll('_', '.').toLowerCase()
+    }).replaceAll('_', '.').toLowerCase(),
+    registrationBody,
+    registration
   }
 
   return user

--- a/app/views/_macros/events-list.njk
+++ b/app/views/_macros/events-list.njk
@@ -5,7 +5,10 @@
     <p class="nhsuk-body">{{ item.name }}</p>
     <p class="nhsuk-hint nhsuk-u-font-size-16">
       {%- if item.user -%}
-        <a href="mailto:{{ item.user.email }}">{{ item.user.fullName }}</a>,
+        <a href="mailto:{{ item.user.email }}">
+          {{ item.user.fullName -}}{%- if item.user.registration %},
+          {{ item.user.registration }}{% endif %}
+        </a><br>
       {% endif -%}
       {{ item.date | govukDateTime }}
     </p>

--- a/app/views/patient/_outcome.html
+++ b/app/views/patient/_outcome.html
@@ -47,9 +47,13 @@
         value: session.location
       },
       {
-        key: "Vaccinator",
-        value: "You (" + data.user.fullName + ")"
+        key: "Vaccinator" if vaccineGiven else "Nurse",
+        value: data.user.fullName + ", " + data.user.registration
       },
+      {
+        key: "Protocol",
+        value: "Patient Group Directions"
+      } if vaccineGiven,
       {
         key: "Notes",
         value: vaccination.notes | default("None", true)

--- a/app/views/users/index.html
+++ b/app/views/users/index.html
@@ -3,48 +3,49 @@
 {% set title = "Manage team" %}
 
 {% block content %}
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-two-thirds">
-      {% set html %}
-        <p class="govuk-notification-banner__heading">
-          {% if success == "invited" %}
-            <a href="/emails/invite-new-user" class="app-u-hidden-link">Invite sent</a>
-          {% else %}
-            Changes saved
-          {% endif %}
-        </p>
-      {% endset %}
+  {% set html %}
+    <p class="govuk-notification-banner__heading">
+      {% if success == "invited" %}
+        <a href="/emails/invite-new-user" class="app-u-hidden-link">Invite sent</a>
+      {% else %}
+        Changes saved
+      {% endif %}
+    </p>
+  {% endset %}
 
-      {{ govukNotificationBanner({
-        html: html,
-        type: "success"
-      }) if success }}
+  {{ govukNotificationBanner({
+    html: html,
+    type: "success"
+  }) if success }}
 
-      {{ heading({ title: title, size: "xl" }) }}
+  {{ heading({ title: title, size: "xl" }) }}
 
-      {{ button({
-        text: "Add a team member",
-        href: "/users/new"
-      }) }}
+  {{ button({
+    text: "Invite a team member",
+    href: "/users/new"
+  }) }}
 
-      <table class="nhsuk-table">
-        <thead class="nhsuk-table__head">
-          <tr class="nhsuk-table__row">
-            <th class="nhsuk-table__header">Name</th>
-            <th class="nhsuk-table__header">Email address</th>
-          </tr>
-        </thead>
-        <tbody class="nhsuk-table__body">
-          {% for id, user in data.users %}
-            <tr class="nhsuk-table__row">
-              <td class="nhsuk-table__cell">
-                <a href="/users/{{ id }}">{{ user.fullName }}</a>
-              </td>
-              <td class="nhsuk-table__cell">{{ user.email }}</td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  </div>
+  <table class="nhsuk-table">
+    <thead class="nhsuk-table__head">
+      <tr class="nhsuk-table__row">
+        <th class="nhsuk-table__header">Name</th>
+        <th class="nhsuk-table__header">Registration</th>
+        <th class="nhsuk-table__header">Email address</th>
+      </tr>
+    </thead>
+    <tbody class="nhsuk-table__body">
+      {% for id, user in data.users %}
+        <tr class="nhsuk-table__row">
+          <td class="nhsuk-table__cell">
+            <a href="/users/{{ id }}">{{ user.fullName }}</a>
+          </td>
+          <td class="nhsuk-table__cell">
+            {{ user.registration }}
+            ({{ user.registrationBody | upper | replace("GPHC", "GPhC") }})
+          </td>
+          <td class="nhsuk-table__cell">{{ user.email }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
 {% endblock %}

--- a/app/views/users/new.html
+++ b/app/views/users/new.html
@@ -17,6 +17,7 @@
       <form method="post">
         {{ input({
           label: {
+            classes: "nhsuk-label--s",
             text: "Their full name"
           },
           decorate: "users.new.fullName"
@@ -24,6 +25,7 @@
 
         {{ input({
           label: {
+            classes: "nhsuk-label--s",
             text: "Their email address"
           },
           hint: {

--- a/app/views/users/user.html
+++ b/app/views/users/user.html
@@ -17,6 +17,7 @@
       <form method="post" action="/users?success={{ user.id }}">
         {{ input({
           label: {
+            classes: "nhsuk-label--s",
             text: "Name"
           },
           decorate: "users." + user.id + ".fullName"
@@ -24,9 +25,45 @@
 
         {{ input({
           label: {
+            classes: "nhsuk-label--s",
             text: "Email address"
           },
           decorate: "users." + user.id + ".email"
+        }) }}
+
+        {{ radios({
+          fieldset: {
+            legend: {
+              classes: "nhsuk-fieldset__legend--s",
+              text: "Professional body"
+            }
+          },
+          items: [{
+            text: "General Medical Council",
+            value: "gmc"
+          }, {
+            text: "General Pharmaceutical Council",
+            value: "gphc"
+          }, {
+            text: "Health and Care Professions Council",
+            value: "hcpc"
+          }, {
+            text: "Nursing and Midwifery Council",
+            value: "nmc"
+          }],
+          decorate: "users." + user.id + ".registrationBody"
+        }) }}
+
+        {{ input({
+          classes: "nhsuk-input--width-10",
+          label: {
+            classes: "nhsuk-label--s",
+            text: "Registration number"
+          },
+          hint: {
+            text: "Also known as a GMC number or nurse’s pin number"
+          },
+          decorate: "users." + user.id + ".registration"
         }) }}
 
         {{ button({

--- a/app/views/vaccination/_multiple-vaccine-summary.html
+++ b/app/views/vaccination/_multiple-vaccine-summary.html
@@ -24,8 +24,12 @@
     },
     {
       key: "Vaccinator",
-      value: "You (" + data.user.fullName + ")",
+      value: data.user.fullName + ", " + data.user.registration,
       href: "#"
+    },
+    {
+      key: "Protocol",
+      value: "Patient Group Directions"
     }
   ])
 }) }}

--- a/app/views/vaccination/_single-vaccine-summary.html
+++ b/app/views/vaccination/_single-vaccine-summary.html
@@ -65,8 +65,12 @@
     },
     {
       key: "Vaccinator",
-      value: "You (" + data.user.fullName + ")",
+      value: data.user.fullName + ", " + data.user.registration,
       href: "#"
+    },
+    {
+      key: "Protocol",
+      value: "Patient Group Directions"
     }
   ])
 }) }}


### PR DESCRIPTION
## Manage users

### View all

Show registration number, with registration body initials in brackets

<img width="1010" alt="Screenshot of Manage users page." src="https://github.com/nhsuk/manage-childrens-vaccinations-prototype/assets/813383/2b8ffc48-6f8b-45cc-9b1d-7dccef5eaf8a">

### Invite user

We don’t have a signup flow yet, but we’d ask for professional body and registration number there, so for inviting a user, keep this page to just name and email address:

<img width="680" alt="Screenshot of Invite a team member page." src="https://github.com/nhsuk/manage-childrens-vaccinations-prototype/assets/813383/6586c12e-ebdb-41e0-a930-f8cae7d1fd47">

### Edit user

A user could edit these values, but we don’t have that flow design yet. Should an admin be able to edit these details? TBD, but for now, I’ve added fields for professional body and registration number to the edit user page:

<img width="670" alt="Screenshot of user edit page." src="https://github.com/nhsuk/manage-childrens-vaccinations-prototype/assets/813383/ab61859f-01c4-4c40-9f2e-e0d30dada4c5">

## Triage

Throughout the interface, wherever we show a user, we show their registration number after their name, for example in triage notes:

![Screenshot of a triage note.](https://github.com/nhsuk/manage-childrens-vaccinations-prototype/assets/813383/0e38c63a-bd01-4b2f-b0fd-363d1ff1fbb9)


## Vaccination

We also show registration number in a vaccination outcome. Here, also showing the hardcoded protocol vaccinations are undertaken under:

<img width="660" alt="Screenshot of vaccination outcome." src="https://github.com/nhsuk/manage-childrens-vaccinations-prototype/assets/813383/1e5341e0-0abe-4462-912a-66c92d647ba3">
