### PR TITLE
Add phase banner, additional checkbox to screener

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,7 @@ $govuk-font-family: "Frutiger W01", arial, sans-serif;
 $govuk-global-styles: false;
 $govuk-new-link-styles: true;
 $govuk-assets-path: "/govuk/assets/";
+$govuk-border-colour: #d8dde0;
 
 @import "node_modules/nhsuk-frontend/packages/nhsuk";
 
@@ -42,4 +43,9 @@ $govuk-assets-path: "/govuk/assets/";
 .nhsuk-fieldset__legend--s {
   padding-top: nhsuk-spacing(2);
   margin-bottom: nhsuk-spacing(2);
+}
+
+// GOV.UK Frontend overrides
+.govuk-phase-banner__content__tag {
+  background-color: $color_nhsuk-blue;
 }

--- a/app/views/_layouts/default.html
+++ b/app/views/_layouts/default.html
@@ -66,6 +66,13 @@
       }
     ]
   }) }}
+  {{ govukPhaseBanner({
+    classes: "nhsuk-width-container",
+    tag: {
+      text: "Pilot"
+    },
+    text: "This is a pilot service. Do not use it to make clinical decisions."
+  }) | replace("govuk-tag", "nhsuk-tag") }}
 {% endblock %}
 
 {% block footer %}

--- a/app/views/pilot/screener/index.html
+++ b/app/views/pilot/screener/index.html
@@ -208,7 +208,15 @@
 
     {{ checkboxes({
       items: [
-        { text: "I agree to the terms and conditions" }
+        {
+          text: "I agree to the terms and conditions"
+          },
+        {
+          text: "I confirm I’ve responded to the school’s regular request for consent for my child's HPV vaccination",
+          hint: {
+            text: "You can only take part in the pilot if you’ve done this"
+          }
+        }
       ],
       decorate: "terms"
     }) }}


### PR DESCRIPTION
### Phase banner

<img width="720" alt="Screenshot of phase banner." src="https://github.com/nhsuk/manage-childrens-vaccinations-prototype/assets/813383/4221ea86-13f1-4806-adec-08ef0fe1f284">

### Screener

<img width="780" alt="Screenshot of additional checkbox." src="https://github.com/nhsuk/manage-childrens-vaccinations-prototype/assets/813383/671e4bd4-c1f7-4edc-aa9d-865b8a8b274e">