### PR TITLE
Unmatched responses

### DIFF
--- a/app/fakers/response.js
+++ b/app/fakers/response.js
@@ -65,6 +65,7 @@ const _getResponse = (type, options) => {
   const child = structuredClone(options.patient)
   child.lastName = faker.person.lastName()
   child.fullName = `${child.firstName} ${child.lastName}`
+  delete child.responses
 
   const refusalReason = _getRefusalReason(type)
   const method = faker.helpers.weightedArrayElement([
@@ -81,7 +82,11 @@ const _getResponse = (type, options) => {
     date: faker.date.recent({ days: 50 }),
     status,
     ...isUnmatchedResponse && {
-      child
+      child,
+      archived: faker.helpers.weightedArrayElement([
+        { weight: 9, value: false },
+        { weight: 1, value: true }
+      ])
     },
     parentOrGuardian: user,
     ...(status === RESPONSE_CONSENT.GIVEN) && {

--- a/app/filters.js
+++ b/app/filters.js
@@ -99,7 +99,7 @@ export default (_env) => {
    */
   filters.highlightDifference = (a, b) => {
     if (a !== b) {
-      return `<mark>${a}</mark>`
+      return `<span class="nhsuk-u-visually-hidden">Inconsistent: </span><mark>${a}</mark>`
     }
 
     return a

--- a/app/views/response/_patient-summary.html
+++ b/app/views/response/_patient-summary.html
@@ -1,7 +1,7 @@
 {{ summaryList({
   rows: decorateRows([
     {
-      key: "Child’s name",
+      key: "Name",
       value: response.child.fullName
     },
     {

--- a/app/views/response/archive.html
+++ b/app/views/response/archive.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/default.html" %}
 
 {% set caption = "Consent response from " + response.parentOrGuardian.fullName %}
-{% set title = "Are you sure you want to delete this consent response?" %}
+{% set title = "Are you sure you want to archive this consent response?" %}
 
 {% block outerContent %}
   {{ backLink({
@@ -18,12 +18,12 @@
         title: title
       }) }}
 
-      <p>You should only delete a consent response if you can’t find a matching child record for {{ response.child.fullName }}.</p>
+      <p>You should only archive a consent response if you can’t find a matching child record for {{ response.child.fullName }}.</p>
 
-      <form class="govuk-button-group" action="/sessions/{{ session.id }}/unmatched-responses?deletedResponse=1" method="post">
+      <form class="govuk-button-group" action="/sessions/{{ session.id }}/unmatched-responses?archivedResponse=1" method="post">
         {{ button({
           classes: " app-button--warning nhsuk-u-margin-right-3",
-          text: "Yes, delete this consent response"
+          text: "Yes, archive this consent response"
         }) }}
         <p><a class="nhsuk-link" href="/sessions/{{ session.id }}/unmatched-responses">No, return to unmatched consent responses</a></p>
       </form>

--- a/app/views/response/index.html
+++ b/app/views/response/index.html
@@ -1,11 +1,11 @@
 {% extends "_layouts/default.html" %}
 
 {% set patient = data.patient | patientFromNHSNumber(session) %}
-{% set title = patient.fullName %}
+{% set title = "Consent response from " + response.parentOrGuardian.fullName %}
 
 {% block outerContent %}
   {{ backLink({
-    href: "/sessions/" + session.id + "/responses/" + response.id + "/match",
+    href: "/sessions/" + session.id + "/unmatched-responses/",
     classes: "nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0"
   }) }}
 {% endblock %}
@@ -15,11 +15,22 @@
 
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-      {% include "patient/_details.html" %}
+      {% set html %}
+        {% include "response/_patient-summary.html" %}
+      {% endset %}
+      {{ card({
+        heading: "Child",
+        headingClasses: "nhsuk-heading-m",
+        descriptionHtml: html
+      }) }}
 
-      {{ button({
-        href: "/sessions/" + session.id + "/responses/" + response.id + "/link?patient=" + data.patient,
-        text: "Select child record"
+      {% set html %}
+        {% include "response/_parent-summary.html" %}
+      {% endset %}
+      {{ card({
+        heading: "Parent or guardian",
+        headingClasses: "nhsuk-heading-m",
+        descriptionHtml: html
       }) }}
     </div>
   </div>

--- a/app/views/response/match.html
+++ b/app/views/response/match.html
@@ -70,7 +70,7 @@
               {% for patient in session.cohort %}
                 <tr class="nhsuk-table__row">
                   <td class="nhsuk-table__cell" data-filter="{{ patient.fullName }} {{ patient.knownAs }}" data-sort="{{ patient.lastName }}">
-                    {{ patient.lastName }}, {{ patient.firstName }}
+                    {{ patient.fullName }}
                     {% if patient.knownAs %}
                       <br><span class="nhsuk-u-font-size-16">Known as: {{ patient.knownAs }}</span>
                     {% endif %}

--- a/app/views/response/match.html
+++ b/app/views/response/match.html
@@ -70,9 +70,7 @@
               {% for patient in session.cohort %}
                 <tr class="nhsuk-table__row">
                   <td class="nhsuk-table__cell" data-filter="{{ patient.fullName }} {{ patient.knownAs }}" data-sort="{{ patient.lastName }}">
-                    <a href="/sessions/{{ session.id }}/responses/{{ response.id }}?patient={{ patient.nhsNumber }}">
-                      {{ patient.lastName }}, {{ patient.firstName }}
-                    </a>
+                    {{ patient.lastName }}, {{ patient.firstName }}
                     {% if patient.knownAs %}
                       <br><span class="nhsuk-u-font-size-16">Known as: {{ patient.knownAs }}</span>
                     {% endif %}

--- a/app/views/schools/school.html
+++ b/app/views/schools/school.html
@@ -39,7 +39,7 @@
           {% for patient in school.cohort %}
             <tr class="nhsuk-table__row">
               <td class="nhsuk-table__cell" data-sort="{{ patient.lastName }}">
-                {{ patient.lastName }}, {{ patient.firstName }}
+                {{ patient.fullName }}
               </td>
               <td class="nhsuk-table__cell" data-sort="{{ patient.dob }}">
                 {{ patient.dob | govukDate }}

--- a/app/views/sessions/_tab.html
+++ b/app/views/sessions/_tab.html
@@ -21,9 +21,7 @@
           {% for patient in tab.results %}
             <tr class="nhsuk-table__row">
               <td class="nhsuk-table__cell" data-sort="{{ patient.lastName }}">
-                <a href="/sessions/{{ session.id }}/patient/{{ patient.nhsNumber }}?referrer={{ section }}">
-                  {{- patient.lastName }}, {{patient.firstName -}}
-                </a>
+                <a href="/sessions/{{ session.id }}/patient/{{ patient.nhsNumber }}?referrer={{ section }}">{{ patient.fullName }}</a>
                 {% if patient.knownAs %}
                   <br><span class="nhsuk-u-font-size-16">Known as: {{ patient.knownAs }}</span>
                 {% endif %}

--- a/app/views/sessions/new/cohort.html
+++ b/app/views/sessions/new/cohort.html
@@ -26,7 +26,7 @@
         html: checkboxHtml(patient.fullName)
       },
       {
-        text: patient.lastName + ", " + patient.firstName
+        text: patient.fullName
       },
       {
         text: patient.dob | govukDate("truncate")

--- a/app/views/sessions/unmatched-responses.html
+++ b/app/views/sessions/unmatched-responses.html
@@ -59,9 +59,9 @@
               <td class="nhsuk-table__cell" data-sort="{{ response.date }}">
                 <span class="nhsuk-table-responsive__heading">Responded </span>{{ response.date | govukDate("truncate") }}
               </td>
-              <td class="nhsuk-table__cell">
+              <td class="nhsuk-table__cell" data-sort="{{ response.child.lastName }}">
                 <span class="nhsuk-table-responsive__heading">Child </span>
-                {{ response.child.lastName }}, {{ response.child.firstName }}
+                {{ response.child.fullName }}
                 {% if response.child.knownAs %}
                   <br><span class="nhsuk-u-font-size-16">Known as: {{ response.child.knownAs }}</span>
                 {% endif %}
@@ -115,7 +115,7 @@
               </td>
               <td class="nhsuk-table__cell">
                 <span class="nhsuk-table-responsive__heading">Child </span>
-                {{ response.child.lastName }}, {{ response.child.firstName }}
+                {{ response.child.fullName }}
                 {% if response.child.knownAs %}
                   <br><span class="nhsuk-u-font-size-16">Known as: {{ response.child.knownAs }}</span>
                 {% endif %}

--- a/app/views/sessions/unmatched-responses.html
+++ b/app/views/sessions/unmatched-responses.html
@@ -24,9 +24,9 @@
   {% include "sessions/_notification-banner.html" %}
 
   {{ govukNotificationBanner({
-    text: "Consent response deleted",
+    text: "Consent response archived",
     type: "success"
-  }) if data.deletedResponse }}
+  }) if data.archivedResponse }}
 
   {% if session["available-offline"] %}
     <span class="app-status app-status--green">
@@ -39,38 +39,44 @@
     caption: title if filteredYearGroup
   }) }}
 
-  {% set responses = session.unmatchedResponses | objectToArray %}
-  {% set descriptionHtml %}
+  {% set responses = session.unmatchedResponses | rejectattr("archived") | objectToArray %}
+  {% set unmatchedResponsesHtml %}
     {% if responses.length %}
     <action-table sort="responded">
-      <table class="nhsuk-table app-table--dense" id="patients">
+      <table class="nhsuk-table nhsuk-table-responsive nhsuk-u-margin-0">
+        <caption class="nhsuk-table__caption">{{ responses.length | plural("unmatched response") }}</caption>
         <thead class="nhsuk-table__head">
           <tr class="nhsuk-table__row">
-            <th class="nhsuk-table__header">Responded</th>
+            <th class="nhsuk-table__header app-u-width-one-fifth">Responded</th>
             <th class="nhsuk-table__header">Child</th>
             <th class="nhsuk-table__header">Parent or guardian</th>
-            <th class="nhsuk-table__header" no-sort>Action</th>
+            <th class="nhsuk-table__header nhsuk-u-width-one-quarter" no-sort>Action</th>
           </tr>
         </thead>
         <tbody class="nhsuk-table__body">
           {% for response in responses %}
             <tr class="nhsuk-table__row">
               <td class="nhsuk-table__cell" data-sort="{{ response.date }}">
-                {{ response.date | govukDate("truncate") }}
+                <span class="nhsuk-table-responsive__heading">Responded </span>{{ response.date | govukDate("truncate") }}
               </td>
               <td class="nhsuk-table__cell">
+                <span class="nhsuk-table-responsive__heading">Child </span>
                 {{ response.child.lastName }}, {{ response.child.firstName }}
                 {% if response.child.knownAs %}
                   <br><span class="nhsuk-u-font-size-16">Known as: {{ response.child.knownAs }}</span>
                 {% endif %}
               </td>
               <td class="nhsuk-table__cell">
+                <span class="nhsuk-table-responsive__heading">Parent or guardian </span>
                 {{ response.parentOrGuardian.fullName }}
               </td>
               <td class="nhsuk-table__cell">
-                <a href="/sessions/{{ session.id }}/responses/{{ response.id }}/match">Find match<span class="nhsuk-u-visually-hidden"> for {{ response.child.fullName }}</span></a>
+                <span class="nhsuk-table-responsive__heading">Actions</span>
+                <span>
+                  <a href="/sessions/{{ session.id }}/responses/{{ response.id }}/match">Find match<span class="nhsuk-u-visually-hidden"> for {{ response.child.fullName }}</span></a>
                 &nbsp;
-                <a href="/sessions/{{ session.id }}/responses/{{ response.id }}/delete">Delete response<span class="nhsuk-u-visually-hidden"> from {{ response.parentOrGuardian.fullName }}</span></a>
+                  <a href="/sessions/{{ session.id }}/responses/{{ response.id }}/archive">Archive<span class="nhsuk-u-visually-hidden"> response from {{ response.parentOrGuardian.fullName }}</span></a>
+                </span>
               </td>
             </tr>
           {% endfor %}
@@ -83,8 +89,56 @@
   {% endset %}
 
   {{ card({
-    heading: responses.length + " responses",
-    headingClasses: "nhsuk-heading-m",
-    descriptionHtml: descriptionHtml
+    descriptionHtml: unmatchedResponsesHtml
+  }) }}
+
+  {% set archived = session.unmatchedResponses | objectToArray | selectattr("archived") %}
+  {% set archivedResponsesHtml %}
+    {% if archived.length %}
+    <action-table sort="responded">
+      <table class="nhsuk-table nhsuk-table-responsive nhsuk-u-margin-0">
+        <caption class="nhsuk-table__caption">{{ archived.length | plural("archived response") }}</caption>
+        <thead class="nhsuk-table__head">
+          <tr class="nhsuk-table__row">
+            <th class="nhsuk-table__header app-u-width-one-fifth">Responded</th>
+            <th class="nhsuk-table__header">Child</th>
+            <th class="nhsuk-table__header">Parent or guardian</th>
+            <th class="nhsuk-table__header nhsuk-u-width-one-quarter">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="nhsuk-table__body">
+          {% for response in archived %}
+            <tr class="nhsuk-table__row">
+              <td class="nhsuk-table__cell" data-sort="{{ response.date }}">
+                <span class="nhsuk-table-responsive__heading">Responded </span>
+                {{ response.date | govukDate("truncate") }}
+              </td>
+              <td class="nhsuk-table__cell">
+                <span class="nhsuk-table-responsive__heading">Child </span>
+                {{ response.child.lastName }}, {{ response.child.firstName }}
+                {% if response.child.knownAs %}
+                  <br><span class="nhsuk-u-font-size-16">Known as: {{ response.child.knownAs }}</span>
+                {% endif %}
+              </td>
+              <td class="nhsuk-table__cell">
+                <span class="nhsuk-table-responsive__heading">Parent or guardian </span>
+                {{ response.parentOrGuardian.fullName }}
+              </td>
+              <td class="nhsuk-table__cell">
+                <span class="nhsuk-table-responsive__heading">Actions</span>
+                <a href="/sessions/{{ session.id }}/responses/{{ response.id }}">View response<span class="nhsuk-u-visually-hidden"> for {{ response.child.fullName }}</span></a>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </action-table>
+    {% else %}
+      <p class="nhsuk-body">There are no archived consent responses.</p>
+    {% endif %}
+  {% endset %}
+
+  {{ card({
+    descriptionHtml: archivedResponsesHtml
   }) }}
 {% endblock %}

--- a/app/views/users/index.html
+++ b/app/views/users/index.html
@@ -36,10 +36,8 @@
     <tbody class="nhsuk-table__body">
       {% for id, user in data.users %}
         <tr class="nhsuk-table__row">
-          <td class="nhsuk-table__cell">
-            <a href="/users/{{ id }}">
-              {{ user.lastName }}, {{ user.firstName }}
-            </a>
+          <td class="nhsuk-table__cell" data-sort="{{ user.lastName }}">
+            <a href="/users/{{ id }}">{{ user.fullName }}</a>
           </td>
           <td class="nhsuk-table__cell">
             {{ user.registration }}


### PR DESCRIPTION
- Archive unmatched consent responses rather than delete them
- Show archived responses on unmatched responses page
- Show visually hidden text (‘Inconsistent: ’) for highlighted differences on linking page
- Remove links to response on matching view, only provide link to ‘Select’
- Revert back to showing patients full name (‘firstName lastName’) instead of ‘lastName, firstName’

<img width="750" alt="Screenshot of unmatched responses page." src="https://github.com/nhsuk/manage-childrens-vaccinations-prototype/assets/813383/db9d643c-54be-4f88-b495-ba7f9ce26c83">