### PR TITLE
Update session scheduling and allow editing a session

### DIFF
--- a/app/routes/new-session.js
+++ b/app/routes/new-session.js
@@ -67,6 +67,9 @@ export default (router) => {
     session.isHPV = session.type === 'HPV'
     session.yearGroups = yearGroups(session.type)
     session.vaccines = _.filter(vaccines, { type: session.type })
+    session.openDate = `${isoDateFromDateInput(session.openDate)}T${time}`
+    session.reminderDate = `${isoDateFromDateInput(session.reminderDate)}T${time}`
+    session.closeDate = `${isoDateFromDateInput(session.closeDate)}T${time}`
 
     req.session.data.sessions[session.id] = session
     delete req.session.data.newCohort

--- a/app/views/sessions/edit.html
+++ b/app/views/sessions/edit.html
@@ -1,0 +1,73 @@
+{% extends "_layouts/wizard.html" %}
+
+{% set title = "Edit session" %}
+{% set buttonText = "Confirm" %}
+{% set baseHref = "/sessions/new/" + sessionId %}
+{% set gridClass = "nhsuk-grid-column-three-quarters" %}
+
+{% block form %}
+  {{ heading({ title: title }) }}
+
+  <div class="nhsuk-card">
+    <div class="nhsuk-card__content">
+      {{ summaryList({
+        rows: decorateRows([
+          {
+            key: "Type of session",
+            value: session.format,
+            href: "#"
+          },
+          {
+            key: "School",
+            value: session.location
+          },
+          {
+            key: "Vaccine",
+            value: session.type
+          },
+          {
+            key: "Date",
+            value: session.date | dateWithDayOfWeek,
+            href: "#"
+          },
+          {
+            key: "Time",
+            value: session.time,
+            href: "#"
+          },
+          {
+            key: "Cohort",
+            value: session.cohort.length + " children"
+          },
+          {
+            key: "Consent requests",
+            value: {
+              classes: "nhsuk-u-secondary-text-color",
+              html: "27 consent requests were sent on<br>26 February 2024"
+            }
+          } if data.state == "past" else {
+            key: "Send consent requests",
+            value: session.openDate | dateWithDayOfWeek,
+            href: "#"
+          },
+          {
+            key: "Reminders",
+            value: {
+              classes: "nhsuk-u-secondary-text-color",
+              html: "27 consent requests were sent on<br>26 February 2024"
+            }
+          } if data.state == "past" else {
+            key: "Send reminders",
+            value: session.reminderDate | dateWithDayOfWeek,
+            href: "#"
+          },
+          {
+            key: "Deadline for responses",
+            value: session.closeDate | dateWithDayOfWeek,
+            href: "#"
+          }
+        ])
+      }) }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/sessions/new/confirm.html
+++ b/app/views/sessions/new/confirm.html
@@ -3,57 +3,66 @@
 {% set title = "Check and confirm details" %}
 {% set buttonText = "Confirm" %}
 {% set baseHref = "/sessions/new/" + sessionId %}
+{% set gridClass = "nhsuk-grid-column-three-quarters" %}
 
 {% block form %}
   {{ heading({ title: title }) }}
 
-  {{ summaryList({
-    rows: decorateRows([
-      {
-        key: "Type of session",
-        value: session.format,
-        href: baseHref
-      },
-      {
-        key: "School",
-        value: session.location,
-        href: baseHref + "/location"
-      },
-      {
-        key: "Vaccine",
-        value: session.type,
-        href: baseHref + "/type"
-      },
-      {
-        key: "Date",
-        value: session.date | isoDateFromDateInput | dateWithDayOfWeek,
-        href: baseHref + "/date"
-      },
-      {
-        key: "Time",
-        value: session.time,
-        href: baseHref + "/date"
-      },
-      {
-        key: "Cohort",
-        value: cohort.length + " children",
-        href: baseHref + "/cohort"
-      },
-      {
-        key: "Consent requests",
-        value: "Send " + (session.requestDays if session.hasRequestDays == "custom" else "14") + " days before the session",
-        href: baseHref + "/schedule"
-      },
-      {
-        key: "Reminders",
-        value: "Send " + (session.reminderDays if session.hasReminderDays == "custom" else "7") + " days after the first consent request",
-        href: baseHref + "/schedule"
-      },
-      {
-        key: "Deadline for responses",
-        value: (session.deadlineDate | isoDateFromDateInput | dateWithDayOfWeek) if session.hasDeadlineDate == "custom" else session.hasDeadlineDate,
-        href: baseHref + "/schedule"
-      }
-    ])
-  }) }}
+  <div class="nhsuk-card">
+    <div class="nhsuk-card__content">
+      {{ summaryList({
+        rows: decorateRows([
+          {
+            key: "Type of session",
+            value: session.format,
+            href: baseHref
+          },
+          {
+            key: "School",
+            value: session.location,
+            href: baseHref + "/location"
+          },
+          {
+            key: "Vaccine",
+            value: session.type,
+            href: baseHref + "/type"
+          },
+          {
+            key: "Date",
+            value: session.date | isoDateFromDateInput | dateWithDayOfWeek,
+            href: baseHref + "/date"
+          },
+          {
+            key: "Time",
+            value: session.time,
+            href: baseHref + "/date"
+          },
+          {
+            key: "Cohort",
+            value: cohort.length + " children",
+            href: baseHref + "/cohort"
+          },
+          {
+            key: "Send consent requests",
+            value: "Today" if data.state == "today" else session.openDate | isoDateFromDateInput | dateWithDayOfWeek,
+            href: baseHref + "/schedule"
+          },
+          {
+            key: "Send reminders",
+            value: session.reminderDate | isoDateFromDateInput | dateWithDayOfWeek if session.hasReminderDate == "custom" else "2 days after the first consent request",
+            href: baseHref + "/schedule"
+          },
+          {
+            key: "Deadline for responses",
+            value: (session.closeDate | isoDateFromDateInput | dateWithDayOfWeek) if session.hasCloseDate == "custom" else session.closeDate,
+            href: baseHref + "/schedule"
+          }
+        ])
+      }) }}
+    </div>
+  </div>
+
+  {{ insetText({
+    HTML: "<p>After clicking confirm, consent request emails will be sent today at 2pm.</p>"
+  }) if data.state == "today" }}
 {% endblock %}

--- a/app/views/sessions/new/schedule.html
+++ b/app/views/sessions/new/schedule.html
@@ -9,7 +9,10 @@
     HTML: "<p>Session scheduled for " + (session.date | isoDateFromDateInput | dateWithDayOfWeek) + " at " + session.location + "</p>"
   }) }}
 
-  {{ radios({
+  {{ dateInput({
+    formGroup: {
+      classes: "nhsuk-u-margin-bottom-6"
+    },
     fieldset: {
       legend: {
         classes: "nhsuk-fieldset__legend--m",
@@ -17,32 +20,10 @@
       }
     },
     hint: {
+      classes: "nhsuk-u-margin-bottom-0",
       text: "When should parents get a request for consent?"
     },
-    items: [
-      {
-        text: "14 days before the session",
-        value: "14"
-      },
-      {
-        text: "Choose your own date",
-        value: "custom",
-        conditional: {
-          html: dateInput({
-            fieldset: {
-              legend: {
-                text: "Date to send consent requests"
-              }
-            },
-            hint: {
-              text: "For example, 27 3 2023"
-            },
-            decorate: ["newSession", "requestDays"]
-          })
-        }
-      }
-    ],
-    decorate: ["newSession", "hasRequestDays"]
+    decorate: ["newSession", "openDate"]
   }) }}
 
   {{ radios({
@@ -57,8 +38,8 @@
     },
     items: [
       {
-        text: "7 days after the first consent request",
-        value: "7"
+        text: "2 days after the first consent request",
+        value: "2"
       },
       {
         text: "Choose your own date",
@@ -73,12 +54,12 @@
             hint: {
               text: "For example, 27 3 2023"
             },
-            decorate: ["newSession", "reminderDays"]
+            decorate: ["newSession", "reminderDate"]
           })
         }
       }
     ],
-    decorate: ["newSession", "hasReminderDays"]
+    decorate: ["newSession", "hasReminderDate"]
   }) }}
 
   {{ radios({
@@ -107,12 +88,12 @@
             hint: {
               text: "For example, 27 3 2023"
             },
-            decorate: ["newSession", "deadlineDate"]
+            decorate: ["newSession", "closeDate"]
           })
         }
       }
     ],
-    decorate: ["newSession", "hasDeadlineDate"]
+    decorate: ["newSession", "hasCloseDate"]
   }) }}
 
 {% endblock %}

--- a/app/views/sessions/session.html
+++ b/app/views/sessions/session.html
@@ -64,7 +64,7 @@
             {% endif %}
 
             <p class="nhsuk-body nhsuk-u-margin-top-6">
-              <a href="#">Edit session</a>
+              <a href="/sessions/{{ session.id }}/edit">Edit session</a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Session timeline

Update schedule form so that:

- Change to only being able to enter a date for when consent requests should be sent (can be today’s date)
- Change default for sending reminders from 7 days to 2 days
- Leave closing consent requests as previous

<img width="690" alt="Screenshot 2024-02-01 at 14 17 40" src="https://github.com/nhsuk/manage-childrens-vaccinations-prototype/assets/813383/8950c43c-0286-4fa4-aa12-168776d4e594">

## Check and confirm details 

Unchanged if date for sending consent requests is in the future:

<img width="750" alt="Screenshot 2024-02-01 at 14 18 20" src="https://github.com/nhsuk/manage-childrens-vaccinations-prototype/assets/813383/319ae9be-0789-4d3a-80a0-6c21ab95b1fa">

If the entered date is today, add additional context above the ‘Confirm’ button:

<img width="755" alt="Screenshot 2024-02-01 at 14 18 37" src="https://github.com/nhsuk/manage-childrens-vaccinations-prototype/assets/813383/d30d29f5-5312-4913-a3e4-f8dbb7d2d05e">

(Idea is that, we’d have a task that sends consent requests on the hour, so if you entered today’s date, and the time now is 2:29pm, emails would be sent at 3pm)



## Editing a session

Add link to edit screen from session landing page:

<img width="665" alt="Screenshot 2024-02-01 at 14 18 48" src="https://github.com/nhsuk/manage-childrens-vaccinations-prototype/assets/813383/b6f50409-b100-401d-bcfe-dfba33fc0e2e">

Add edit screen, so that some values can be changed:

- Type of session
- Date and time of session
- Date to send consent requests (if not already sent)
- Date to send reminders (if not already sent)
- Deadline for consent requests

<img width="750" alt="Screenshot 2024-02-01 at 14 20 27" src="https://github.com/nhsuk/manage-childrens-vaccinations-prototype/assets/813383/0d23c9e9-ae7d-4ef7-be75-c8550ac9445e">

This also provides an area where the status of emails can be seen. If requests (and reminders) have already been sent, play back when and how many where sent:

<img width="740" alt="Screenshot 2024-02-01 at 14 21 13" src="https://github.com/nhsuk/manage-childrens-vaccinations-prototype/assets/813383/def0f958-b6fa-4642-ae78-13953302fa5c">
